### PR TITLE
monter de version des proptypes

### DIFF
--- a/issue-tracker-ui/app/App.js
+++ b/issue-tracker-ui/app/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {render} from 'react-dom';
 import { Router, Route, Redirect, browserHistory, withRouter } from 'react-router';
 import { Navbar, Nav, NavItem, NavDropdown, MenuItem, Glyphicon } from 'react-bootstrap';
@@ -43,7 +44,7 @@ const App = (props) => (
 );
 
 App.propTypes = {
-  children: React.PropTypes.object.isRequired,
+  children: PropTypes.object.isRequired,
 };
 
 const RoutedApp = () => (

--- a/issue-tracker-ui/app/DateInput.js
+++ b/issue-tracker-ui/app/DateInput.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class DateInput extends Component {
   
@@ -68,8 +69,8 @@ export default class DateInput extends Component {
 }
 
 DateInput.propTypes = {
-  value: React.PropTypes.object,
-  onChange: React.PropTypes.func.isRequired,
-  onValidityChange: React.PropTypes.func,
-  name: React.PropTypes.string.isRequired,
+  value: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  onValidityChange: PropTypes.func,
+  name: PropTypes.string.isRequired,
 };

--- a/issue-tracker-ui/app/IssueAdd.js
+++ b/issue-tracker-ui/app/IssueAdd.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Form, FormControl, Button } from 'react-bootstrap';
 
 export default class IssueAdd extends Component {
@@ -40,5 +41,5 @@ export default class IssueAdd extends Component {
 }
 
 IssueAdd.propTypes = {
-  createIssue: React.PropTypes.func.isRequired,
+  createIssue: PropTypes.func.isRequired,
 };

--- a/issue-tracker-ui/app/IssueEdit.js
+++ b/issue-tracker-ui/app/IssueEdit.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import { FormGroup, FormControl, ControlLabel, ButtonToolbar, Button, Panel, Form, Col, Alert } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -239,5 +240,5 @@ export default class IssueEdit extends Component {
 }
 
 IssueEdit.propTypes = {
-  params: React.PropTypes.object.isRequired,
+  params: PropTypes.object.isRequired,
 };

--- a/issue-tracker-ui/app/IssueFilter.js
+++ b/issue-tracker-ui/app/IssueFilter.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Col, Row, FormGroup, FormControl, ControlLabel, InputGroup, ButtonToolbar, Button } from 'react-bootstrap';
 
 /*
@@ -125,6 +126,6 @@ export default class IssueFilter extends Component {
 }
 
 IssueFilter.propTypes = {
-  setFilter: React.PropTypes.func.isRequired,
-  initFilter: React.PropTypes.object.isRequired,
+  setFilter: PropTypes.func.isRequired,
+  initFilter: PropTypes.object.isRequired,
 };

--- a/issue-tracker-ui/app/IssueList.js
+++ b/issue-tracker-ui/app/IssueList.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import { Table, Panel } from 'react-bootstrap';
 //import mockupIssues from '../mockups/issues';
@@ -32,8 +33,8 @@ function IssueTable(props) {
 }
 
 IssueTable.propTypes = {
-  issues: React.PropTypes.array.isRequired,
-  deleteIssue: React.PropTypes.func.isRequired,
+  issues: PropTypes.array.isRequired,
+  deleteIssue: PropTypes.func.isRequired,
 };
 
 export default class IssueList extends Component {
@@ -170,6 +171,6 @@ export default class IssueList extends Component {
 }
 
 IssueList.propTypes = {
-  location: React.PropTypes.object.isRequired,
-  router: React.PropTypes.object,
+  location: PropTypes.object.isRequired,
+  router: PropTypes.object,
 };

--- a/issue-tracker-ui/app/IssueRow.js
+++ b/issue-tracker-ui/app/IssueRow.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { Button, Glyphicon } from 'react-bootstrap';
 
@@ -34,6 +35,6 @@ export default class IssueRow extends Component {
 }
 
 IssueRow.propTypes = {
-  issue: React.PropTypes.object.isRequired,
-  deleteIssue: React.PropTypes.func.isRequired,
+  issue: PropTypes.object.isRequired,
+  deleteIssue: PropTypes.func.isRequired,
 };

--- a/issue-tracker-ui/app/NumInput.js
+++ b/issue-tracker-ui/app/NumInput.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class NumInput extends React.Component {
 
@@ -49,6 +50,6 @@ export default class NumInput extends React.Component {
 }
 
 NumInput.propTypes = {
-  value: React.PropTypes.number,
-  onChange: React.PropTypes.func.isRequired,
+  value: PropTypes.number,
+  onChange: PropTypes.func.isRequired,
 };

--- a/issue-tracker-ui/app/Toast.js
+++ b/issue-tracker-ui/app/Toast.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Alert, Collapse } from 'react-bootstrap';
 
 export default class Toast extends React.Component {
@@ -29,10 +30,10 @@ export default class Toast extends React.Component {
 }
 
 Toast.propTypes = {
-  showing: React.PropTypes.bool.isRequired,
-  onDismiss: React.PropTypes.func.isRequired,
-  bsStyle: React.PropTypes.string,
-  message: React.PropTypes.any.isRequired,
+  showing: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  bsStyle: PropTypes.string,
+  message: PropTypes.any.isRequired,
 };
 
 Toast.defaultProps = {

--- a/issue-tracker-ui/package.json
+++ b/issue-tracker-ui/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "bootstrap": "3.3.7",
+    "prop-types": "^15.7.2",
     "react": "15.5.4",
     "react-bootstrap": "0.30.6",
     "react-dom": "15.5.4",


### PR DESCRIPTION
Ajout de la dépendance prop-types.
Présence de warning suite à des appelles de react.proptypes introuvable. 
Potentielle besoin de monter de version de React pour enlever ce warning.