### PR TITLE
bootstrap 3.3.7 (vulnerable) vers bootstrap 5.1.3

### DIFF
--- a/issue-tracker-ui/package.json
+++ b/issue-tracker-ui/package.json
@@ -14,7 +14,7 @@
     "parcel": "^2.0.0"
   },
   "dependencies": {
-    "bootstrap": "3.3.7",
+    "bootstrap": "5.1.3",
     "prop-types": "^15.7.2",
     "react": "15.5.4",
     "react-bootstrap": "0.30.6",


### PR DESCRIPTION
Vulnérabilité sur l'ancienne version
Aucun impact sur le site 
Aucune modification mise à part la dépendance